### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ea8622b

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "129f1ecdec28bc960a57b18794025878e96d2afa"
+                "reference": "ea8622b82905329bac4e11f9eb75afba75e5c3fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/129f1ecdec28bc960a57b18794025878e96d2afa",
-                "reference": "129f1ecdec28bc960a57b18794025878e96d2afa",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ea8622b82905329bac4e11f9eb75afba75e5c3fa",
+                "reference": "ea8622b82905329bac4e11f9eb75afba75e5c3fa",
                 "shasum": ""
             },
             "require": {
@@ -817,7 +817,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-10T08:51:36+00:00"
+            "time": "2025-12-10T11:29:56+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#129f1ec` to `dev-main#ea8622b`.

This pull request changes the following file(s): 

- Update `composer.lock`