### PR TITLE
Update ghostwriter/coding-standard to version dev-main#52213b4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "c7a0b544b6f38cc46aca97645219a9eb5c907640"
+                "reference": "52213b465f3522ba0d80300ff7817e267b439f85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/c7a0b544b6f38cc46aca97645219a9eb5c907640",
-                "reference": "c7a0b544b6f38cc46aca97645219a9eb5c907640",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/52213b465f3522ba0d80300ff7817e267b439f85",
+                "reference": "52213b465f3522ba0d80300ff7817e267b439f85",
                 "shasum": ""
             },
             "require": {
@@ -818,7 +818,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-27T16:40:43+00:00"
+            "time": "2026-01-28T10:57:22+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#c7a0b54` to `dev-main#52213b4`.

This pull request changes the following file(s): 

- Update `composer.lock`