### PR TITLE
Update `boundwize/structarmed` to version `0.10.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.9.5",
+        "boundwize/structarmed": "^0.10.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cfc5ccf076ecc8d0129e7519d8f7b68",
+    "content-hash": "31ab03fafb0c68b62f8f78c5362a5c1d",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0"
+                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
-                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/5e488b5c1502a92e3cef8cf25b87b77e877b9804",
+                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.9.5"
+                "source": "https://github.com/boundwize/structarmed/tree/0.10.0"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T07:01:44+00:00"
+            "time": "2026-06-01T18:39:11+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.9.5` to `0.10.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`